### PR TITLE
Break the build on new StackHawk findings

### DIFF
--- a/.github/workflows/hawkscan.yml
+++ b/.github/workflows/hawkscan.yml
@@ -30,6 +30,5 @@ jobs:
         run: env
       - name: Run HawkScan
         uses: stackhawk/hawkscan-action@v2.0.0
-        continue-on-error: true
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}


### PR DESCRIPTION
This PR demonstrates how StackHawk can break the CI/CD build workflow when it finds new vulnerabilities in my application.