### PR TITLE
Add HawkScan code scanning alerts

### DIFF
--- a/.github/workflows/hawkscan.yml
+++ b/.github/workflows/hawkscan.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           HAWK_ENV: GitHub Actions
         continue-on-error: true
-        uses: stackhawk/hawkscan-action@v1.3.4
+        uses: stackhawk/hawkscan-action@v2
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}
           codeScanningAlerts: true

--- a/.github/workflows/hawkscan.yml
+++ b/.github/workflows/hawkscan.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           HAWK_ENV: GitHub Actions
         continue-on-error: true
-        uses: stackhawk/hawkscan-action@v2
+        uses: stackhawk/hawkscan-action@main
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}
           codeScanningAlerts: true

--- a/.github/workflows/hawkscan.yml
+++ b/.github/workflows/hawkscan.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           HAWK_ENV: GitHub Actions
         continue-on-error: true
-        uses: stackhawk/hawkscan-action@main
+        uses: stackhawk/hawkscan-action@v1.3.4
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}
           codeScanningAlerts: true

--- a/.github/workflows/hawkscan.yml
+++ b/.github/workflows/hawkscan.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           HAWK_ENV: GitHub Actions
         continue-on-error: true
-        uses: stackhawk/hawkscan-action@v2.0.2
+        uses: stackhawk/hawkscan-action@v2
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}
           codeScanningAlerts: true

--- a/.github/workflows/hawkscan.yml
+++ b/.github/workflows/hawkscan.yml
@@ -36,3 +36,5 @@ jobs:
         uses: stackhawk/hawkscan-action@v2.0.2
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}
+          codeScanningAlerts: true
+          githubToken: ${{ github.token }}

--- a/stackhawk.yml
+++ b/stackhawk.yml
@@ -3,7 +3,6 @@ app:
   env: ${HAWK_ENV:Development} # (required)
   host: http://localhost:3000 # (required)
 
-
 hawk:
   failureThreshold: high
 


### PR DESCRIPTION
This PR adds Code Scanning Alerts to HawkScan. When HawkScan runs in GitHub Actions, it will post an alert to Code Scanning Alerts if there are New security findings that exceed our failure threshold of "high" criticality.